### PR TITLE
Copy Dict input into compute_graph so it is not modified in-place

### DIFF
--- a/src/ITensorsAD/utils.jl
+++ b/src/ITensorsAD/utils.jl
@@ -14,6 +14,7 @@ A list of ITensor tensors.
 """
 function compute_graph(out_nodes, node_dict)
     topo_order = ad.find_topo_sort(out_nodes)
+    node_dict = copy(node_dict)
     for node in topo_order
         if haskey(node_dict, node) == false
             # TODO: change this to general contract


### PR DESCRIPTION
@LinjianMa, this is to make sure the initial Dict mapping the Python tensor variables to the ITensors doesn't get modified in-place (it was inserting the cache results for intermediate tensor contractions).

Is there a reason that we might want to output the Dict with all of the cached values? It seems useful but that could be provided in another functionality or with another interface.